### PR TITLE
Add missing sync and export pages to office area

### DIFF
--- a/src/app/office/export/page.tsx
+++ b/src/app/office/export/page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+/**
+ * Export Page
+ * Allows exporting income entries to CSV for EÜR/tax purposes.
+ */
+
+import { useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { exportIncomeAction } from "@/app/actions/income.actions";
+
+export default function ExportPage() {
+  const [isExporting, setIsExporting] = useState(false);
+
+  // Default to current year
+  const currentYear = new Date().getFullYear();
+  const [startDate, setStartDate] = useState(`${currentYear}-01-01`);
+  const [endDate, setEndDate] = useState(`${currentYear}-12-31`);
+
+  const handleExport = async () => {
+    if (!startDate || !endDate) {
+      toast.error("Bitte wählen Sie Start- und Enddatum");
+      return;
+    }
+
+    setIsExporting(true);
+    try {
+      const result = await exportIncomeAction({ startDate, endDate });
+
+      if (result.success && result.data) {
+        // Create and download CSV file
+        const blob = new Blob([result.data.csv], { type: "text/csv;charset=utf-8;" });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = result.data.filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+
+        toast.success("Export erfolgreich heruntergeladen");
+      } else {
+        toast.error(result.error || "Export fehlgeschlagen");
+      }
+    } catch (error) {
+      toast.error(`Fehler: ${String(error)}`);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  // Quick select buttons
+  const setQuarter = (quarter: 1 | 2 | 3 | 4) => {
+    const start = new Date(currentYear, (quarter - 1) * 3, 1);
+    const end = new Date(currentYear, quarter * 3, 0);
+    const startDateStr = start.toISOString().split("T")[0];
+    const endDateStr = end.toISOString().split("T")[0];
+    if (startDateStr && endDateStr) {
+      setStartDate(startDateStr);
+      setEndDate(endDateStr);
+    }
+  };
+
+  const setYear = (year: number) => {
+    setStartDate(`${year}-01-01`);
+    setEndDate(`${year}-12-31`);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Zeitraum wählen</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+          {/* Quick Select */}
+          <div className="space-y-2">
+            <Label>Schnellauswahl</Label>
+            <div className="grid grid-cols-2 gap-2">
+              <Button variant="outline" onClick={() => setQuarter(1)}>
+                Q1 {currentYear}
+              </Button>
+              <Button variant="outline" onClick={() => setQuarter(2)}>
+                Q2 {currentYear}
+              </Button>
+              <Button variant="outline" onClick={() => setQuarter(3)}>
+                Q3 {currentYear}
+              </Button>
+              <Button variant="outline" onClick={() => setQuarter(4)}>
+                Q4 {currentYear}
+              </Button>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <Button variant="outline" onClick={() => setYear(currentYear)}>
+                Jahr {currentYear}
+              </Button>
+              <Button variant="outline" onClick={() => setYear(currentYear - 1)}>
+                Jahr {currentYear - 1}
+              </Button>
+            </div>
+          </div>
+
+          {/* Custom Range */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="startDate">Von</Label>
+              <Input
+                id="startDate"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="min-h-11"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="endDate">Bis</Label>
+              <Input
+                id="endDate"
+                type="date"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                className="min-h-11"
+              />
+            </div>
+          </div>
+
+          {/* Export Button */}
+          <Button
+            className="w-full min-h-12"
+            onClick={() => void handleExport()}
+            disabled={isExporting}
+          >
+            {isExporting ? (
+              <>
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                Wird exportiert...
+              </>
+            ) : (
+              <>
+                <Download className="mr-2 h-5 w-5" />
+                CSV herunterladen
+              </>
+            )}
+          </Button>
+
+          {/* Format Info */}
+          <p className="text-sm text-muted-foreground">
+            Die CSV-Datei enthält: Datum, Betrag, Zahlungsart, Behandlung, Kunde, Notizen.
+            Format ist kompatibel mit Excel und ELSTER.
+          </p>
+        </CardContent>
+    </Card>
+  );
+}

--- a/src/app/office/sync/page.tsx
+++ b/src/app/office/sync/page.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+/**
+ * Sync Logs Page (with React Query)
+ * Shows Outlook calendar sync history and allows manual sync.
+ */
+
+import { RefreshCw, CheckCircle2, XCircle, Clock, Loader2, ChevronDown, AlertCircle } from "lucide-react";
+import { toast } from "sonner";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import {
+  getSyncLogsAction,
+  triggerSyncAction,
+} from "@/app/actions/sync.actions";
+import type { SyncLog } from "@/lib/db/schema";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Format duration between two dates.
+ */
+function formatDuration(start: Date, end: Date | null): string {
+  if (!end) return "laufend...";
+  const ms = end.getTime() - start.getTime();
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${seconds % 60}s`;
+}
+
+/**
+ * Format date/time in German.
+ */
+function formatDateTime(date: Date): string {
+  return date.toLocaleString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Get status badge variant and label.
+ */
+function getStatusBadge(status: SyncLog["status"]) {
+  switch (status) {
+    case "success":
+      return {
+        icon: <CheckCircle2 className="h-3.5 w-3.5" />,
+        label: "Erfolgreich",
+        className: "bg-green-500 hover:bg-green-500/80 text-white",
+      };
+    case "error":
+      return {
+        icon: <XCircle className="h-3.5 w-3.5" />,
+        label: "Fehler",
+        className: "bg-red-500 hover:bg-red-500/80 text-white",
+      };
+    case "in_progress":
+      return {
+        icon: <Loader2 className="h-3.5 w-3.5 animate-spin" />,
+        label: "Läuft",
+        className: "bg-blue-500 hover:bg-blue-500/80 text-white",
+      };
+    case "cancelled":
+      return {
+        icon: <XCircle className="h-3.5 w-3.5" />,
+        label: "Abgebrochen",
+        className: "bg-gray-500 hover:bg-gray-500/80 text-white",
+      };
+  }
+}
+
+/**
+ * Sync Log Item Component
+ */
+function SyncLogItem({ log }: { log: SyncLog }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const statusBadge = getStatusBadge(log.status);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border p-3 lg:flex-row lg:items-center lg:justify-between">
+      {/* Left: Time and Status */}
+      <div className="flex items-center gap-2 lg:flex-1 min-w-0">
+        <Clock className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+        <div className="flex items-center gap-2 flex-wrap flex-1 min-w-0">
+          <span className="font-medium text-sm">
+            {formatDateTime(log.syncStartedAt)}
+          </span>
+          <Badge variant="default" className={statusBadge.className}>
+            {statusBadge.icon}
+            <span className="ml-1">{statusBadge.label}</span>
+          </Badge>
+          {log.message && (
+            <span className="text-sm text-muted-foreground">
+              {log.message}
+            </span>
+          )}
+
+        </div>
+      </div>
+
+      {/* Right: Stats */}
+      <div className="flex gap-4 text-sm lg:flex-shrink-0">
+        <div className="flex flex-col">
+          <span className="text-muted-foreground">Importiert</span>
+          <span className="font-medium text-green-600">
+            {log.appointmentsImported}
+          </span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-muted-foreground">Übersprungen</span>
+          <span className="font-medium text-gray-600">
+            {log.appointmentsSkipped}
+          </span>
+        </div>
+        {log.appointmentsFailed > 0 && (
+          <div className="flex flex-col">
+            <span className="text-muted-foreground">Fehler</span>
+            <span className="font-medium text-red-600">
+              {log.appointmentsFailed}
+            </span>
+          </div>
+        )}
+        <div className="flex flex-col">
+          <span className="text-muted-foreground">Dauer</span>
+          <span className="font-medium">
+            {formatDuration(log.syncStartedAt, log.syncEndedAt)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function SyncPage() {
+  const queryClient = useQueryClient();
+
+  // Fetch sync logs with React Query
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["sync-logs"],
+    queryFn: async () => {
+      const result = await getSyncLogsAction({ page: 1, limit: 50 });
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+      return result.data!;
+    },
+  });
+
+  // Manual sync mutation
+  const syncMutation = useMutation({
+    mutationFn: async () => {
+      const result = await triggerSyncAction();
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+      return result.data;
+    },
+    onSuccess: () => {
+      toast.success("Synchronisierung erfolgreich");
+      // Invalidate and refetch logs
+      void queryClient.invalidateQueries({ queryKey: ["sync-logs"] });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Fehler beim Synchronisieren");
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6 max-w-4xl">
+        <Skeleton className="h-10 w-48" />
+        <Skeleton className="h-32" />
+        <Skeleton className="h-64" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="space-y-6 max-w-4xl">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Fehler</AlertTitle>
+          <AlertDescription>
+            {error.message || "Fehler beim Laden der Sync-Logs"}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Manual sync button */}
+      <div className="flex justify-end">
+        <Button
+          onClick={() => syncMutation.mutate()}
+          disabled={syncMutation.isPending}
+        >
+          {syncMutation.isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Synchronisiert...
+            </>
+          ) : (
+            <>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Jetzt synchronisieren
+            </>
+          )}
+        </Button>
+      </div>
+
+      {/* Sync History */}
+      <div>
+        {!data || data.items.length === 0 ? (
+          <p className="text-center text-muted-foreground py-8">
+            Noch keine Synchronisierungen durchgeführt
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {data.items.map((log) => (
+              <SyncLogItem key={log.id} log={log} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds the missing `/office/sync` and `/office/export` pages that were causing 404 errors in production.

## Changes
- ✅ Added `/office/sync` page for Outlook calendar synchronization
- ✅ Added `/office/export` page for EÜR data export  
- ✅ Both pages restored from previous implementation

## Issue
These pages existed in the codebase but were not tracked in git, causing them to work locally but return 404 in production. The navigation links were pointing to these routes but the pages were missing from the repository.

## Testing
- ✅ Build passes successfully
- ✅ Pages render correctly with proper functionality
- ✅ Navigation links now work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV export functionality for income entries with flexible date range selection (default: current year), quick-select buttons for quarters/years, and custom date inputs. Exported files support Excel and ELSTER compatibility.
  * Added sync history dashboard displaying Outlook calendar synchronization logs with pagination, status badges, timestamps, and per-sync statistics (imported/skipped/failed counts and duration). Users can trigger manual sync from the dashboard.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->