### PR TITLE
Fix React Query cache invalidation for treatment mutations

### DIFF
--- a/src/hooks/use-treatments.ts
+++ b/src/hooks/use-treatments.ts
@@ -9,6 +9,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getTreatmentsAction,
   getActiveTreatmentsAction,
+  createTreatmentAction,
+  updateTreatmentAction,
   deleteTreatmentAction,
 } from '@/app/actions/treatment.actions';
 import { queryKeys } from '@/lib/query-keys';
@@ -92,6 +94,89 @@ export function useDeleteTreatment() {
     },
     onSettled: () => {
       // Refetch to ensure cache consistency
+      void queryClient.invalidateQueries({ queryKey: queryKeys.treatments.lists() });
+    },
+  });
+}
+
+/**
+ * Mutation hook for creating a treatment.
+ * Invalidates cache on success to trigger refetch.
+ *
+ * @returns Mutation object with mutate function
+ *
+ * @example
+ * ```tsx
+ * const createMutation = useCreateTreatment();
+ *
+ * createMutation.mutate(data, {
+ *   onSuccess: () => toast.success("Created"),
+ *   onError: (error) => toast.error(error.message),
+ * });
+ * ```
+ */
+export function useCreateTreatment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: {
+      name: string;
+      description?: string;
+      defaultPrice: string;
+      isActive: boolean;
+      sortOrder?: number;
+    }) => {
+      const result = await createTreatmentAction({
+        ...data,
+        sortOrder: data.sortOrder ?? 0,
+      });
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to create treatment');
+      }
+      return result;
+    },
+    onSuccess: () => {
+      // Invalidate and refetch treatments list
+      void queryClient.invalidateQueries({ queryKey: queryKeys.treatments.lists() });
+    },
+  });
+}
+
+/**
+ * Mutation hook for updating a treatment.
+ * Invalidates cache on success to trigger refetch.
+ *
+ * @returns Mutation object with mutate function
+ *
+ * @example
+ * ```tsx
+ * const updateMutation = useUpdateTreatment();
+ *
+ * updateMutation.mutate({ id: '123', name: 'New Name' }, {
+ *   onSuccess: () => toast.success("Updated"),
+ *   onError: (error) => toast.error(error.message),
+ * });
+ * ```
+ */
+export function useUpdateTreatment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: {
+      id: string;
+      name?: string;
+      description?: string | null;
+      defaultPrice?: string;
+      isActive?: boolean;
+    }) => {
+      const result = await updateTreatmentAction(data);
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to update treatment');
+      }
+      return result;
+    },
+    onSuccess: () => {
+      // Invalidate and refetch treatments list
       void queryClient.invalidateQueries({ queryKey: queryKeys.treatments.lists() });
     },
   });


### PR DESCRIPTION
## Problem
After creating or updating a treatment (Behandlung), the page was stuck in loading state and the treatment list wasn't automatically updated.

## Root Cause
The `TreatmentForm` component was calling server actions directly and using `router.refresh()`, which doesn't trigger React Query cache invalidation. This caused the UI to show stale cached data.

## Solution

### Added Mutation Hooks
- ✅ `useCreateTreatment()` - Mutation hook for creating treatments
- ✅ `useUpdateTreatment()` - Mutation hook for updating treatments
- Both hooks include automatic cache invalidation on success

### Updated TreatmentForm Component
- ✅ Now uses mutation hooks instead of calling actions directly
- ✅ Proper loading states from `mutation.isPending`
- ✅ Removed unnecessary `router.refresh()` calls
- ✅ Cache automatically refreshes after mutations

## Result
- Treatment list updates immediately after create/update operations
- No more stuck loading state
- Proper React Query cache management
- Better user experience with instant feedback

## Technical Details
- Mutations use `queryClient.invalidateQueries()` to trigger refetch
- Form loading state tied to `mutation.isPending`
- Follows same pattern as existing `useDeleteTreatment` hook

## Testing
- ✅ Build passes successfully
- ✅ Create treatment triggers cache invalidation
- ✅ Update treatment triggers cache invalidation
- ✅ List updates immediately after mutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal treatment form submission architecture for enhanced maintainability and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->