### PR TITLE
Add delete button for customers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import "../styles/globals.css";
 import "keen-slider/keen-slider.min.css";
 import "react-toastify/dist/ReactToastify.css";
-import { ToastContainer } from "react-toastify";
 import GoogleAnalytics from "../components/GoogleAnalytics";
 import { AxiomWebVitals } from "next-axiom";
 import { RootProviders } from "@/components/providers/root-providers";
@@ -34,7 +33,6 @@ export default function RootLayout({
         <AxiomWebVitals />
         <GoogleAnalytics />
         <RootProviders>{children}</RootProviders>
-        <ToastContainer />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import "../styles/globals.css";
 import "keen-slider/keen-slider.min.css";
-import "react-toastify/dist/ReactToastify.css";
 import GoogleAnalytics from "../components/GoogleAnalytics";
 import { AxiomWebVitals } from "next-axiom";
 import { RootProviders } from "@/components/providers/root-providers";

--- a/src/app/office/behandlungen/[id]/bearbeiten/page.tsx
+++ b/src/app/office/behandlungen/[id]/bearbeiten/page.tsx
@@ -1,0 +1,55 @@
+/**
+ * Edit Treatment Page
+ * Server component that fetches treatment data and renders the TreatmentForm in edit mode.
+ */
+
+import { notFound } from "next/navigation";
+import { TreatmentForm } from "@/components/treatments/treatment-form";
+import { treatmentService } from "@/lib/services/treatment.service";
+import { isErrResult } from "@/lib/services/types";
+
+export const metadata = {
+  title: "Behandlung bearbeiten",
+  description: "Bearbeiten Sie die Behandlungsdaten",
+};
+
+interface EditTreatmentPageProps {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * Page for editing an existing treatment.
+ * Fetches treatment data and renders the TreatmentForm in edit mode with pre-filled values.
+ */
+export default async function EditTreatmentPage({
+  params,
+}: EditTreatmentPageProps) {
+  const { id } = await params;
+
+  // Fetch treatment data
+  const result = await treatmentService.getById(id);
+
+  if (isErrResult(result)) {
+    notFound();
+  }
+
+  const treatment = result.value;
+
+  // Map treatment data to form values
+  const defaultValues = {
+    name: treatment.name,
+    description: treatment.description ?? "",
+    defaultPrice: treatment.defaultPrice,
+    isActive: treatment.isActive,
+  };
+
+  return (
+    <div className="container max-w-2xl py-6">
+      <TreatmentForm
+        mode="edit"
+        treatmentId={treatment.id}
+        defaultValues={defaultValues}
+      />
+    </div>
+  );
+}

--- a/src/app/office/kunden/[id]/page.tsx
+++ b/src/app/office/kunden/[id]/page.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import { useParams, useRouter, notFound } from "next/navigation";
 import Link from "next/link";
 import { Pencil, FileSignature, Mail, Phone, FileText, ArrowLeft, CheckCircle, AlertCircle, Users, Activity, Loader2, Trash2 } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "sonner";
 
 import { useCustomerDetail, useDeleteCustomer } from "@/hooks/use-customers";
 import { formatDate } from "@/lib/utils";

--- a/src/components/providers/root-providers.tsx
+++ b/src/components/providers/root-providers.tsx
@@ -6,8 +6,8 @@
  */
 
 import { Suspense } from "react";
-import { ToastContainer } from "react-toastify";
 import { NavigationProgress } from "./navigation-progress";
+import { ToastProvider } from "./toast-provider";
 import { QueryProvider } from "@/lib/query-client";
 
 export function RootProviders({ children }: { children: React.ReactNode }) {
@@ -17,7 +17,7 @@ export function RootProviders({ children }: { children: React.ReactNode }) {
         <NavigationProgress />
       </Suspense>
       {children}
-      <ToastContainer />
+      <ToastProvider />
     </QueryProvider>
   );
 }

--- a/src/components/providers/root-providers.tsx
+++ b/src/components/providers/root-providers.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Suspense } from "react";
+import { ToastContainer } from "react-toastify";
 import { NavigationProgress } from "./navigation-progress";
 import { QueryProvider } from "@/lib/query-client";
 
@@ -16,6 +17,7 @@ export function RootProviders({ children }: { children: React.ReactNode }) {
         <NavigationProgress />
       </Suspense>
       {children}
+      <ToastContainer />
     </QueryProvider>
   );
 }

--- a/src/components/providers/toast-provider.tsx
+++ b/src/components/providers/toast-provider.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+/**
+ * Toast Provider
+ * Client-side wrapper for react-toastify's ToastContainer.
+ * Handles the client-side only import to avoid SSR issues.
+ */
+
+import dynamic from "next/dynamic";
+
+const ToastContainer = dynamic(
+  () => import("react-toastify").then((mod) => mod.ToastContainer),
+  { ssr: false }
+);
+
+export function ToastProvider() {
+  return <ToastContainer />;
+}

--- a/src/components/providers/toast-provider.tsx
+++ b/src/components/providers/toast-provider.tsx
@@ -2,17 +2,11 @@
 
 /**
  * Toast Provider
- * Client-side wrapper for react-toastify's ToastContainer.
- * Handles the client-side only import to avoid SSR issues.
+ * Client-side wrapper for sonner's Toaster component.
  */
 
-import dynamic from "next/dynamic";
-
-const ToastContainer = dynamic(
-  () => import("react-toastify").then((mod) => mod.ToastContainer),
-  { ssr: false }
-);
+import { Toaster } from "sonner";
 
 export function ToastProvider() {
-  return <ToastContainer />;
+  return <Toaster position="top-right" richColors />;
 }

--- a/src/components/treatments/treatment-table.tsx
+++ b/src/components/treatments/treatment-table.tsx
@@ -11,7 +11,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { Search, ChevronLeft, ChevronRight, Trash2 } from "lucide-react";
+import { Search, ChevronLeft, ChevronRight, Trash2, Pencil } from "lucide-react";
 import {
   Table,
   TableBody,
@@ -120,7 +120,16 @@ export function TreatmentTable({
         id: "actions",
         header: "",
         cell: ({ row }) => (
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-1">
+            <Link href={`/office/behandlungen/${row.original.id}/bearbeiten`}>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9 text-blue-500 hover:text-blue-600 hover:bg-blue-50"
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
+            </Link>
             <Button
               variant="ghost"
               size="icon"

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/hooks/use-customers.ts
+++ b/src/hooks/use-customers.ts
@@ -9,9 +9,12 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getCustomersListAction,
   getCustomerDetailAction,
+  createCustomerAction,
+  updateCustomerAction,
   deleteCustomerAction,
 } from '@/app/actions/customer.actions';
 import { queryKeys } from '@/lib/query-keys';
+import type { CustomerFormData } from '@/components/customers/customer-form';
 
 /**
  * Query hook for fetching customers list.
@@ -61,6 +64,75 @@ export function useCustomerDetail(id: string) {
         throw new Error(result.error || 'Failed to fetch customer detail');
       }
       return result.data;
+    },
+  });
+}
+
+/**
+ * Mutation hook for creating a customer.
+ * Invalidates cache on success.
+ *
+ * @returns Mutation object with mutate function and created customer ID
+ *
+ * @example
+ * ```tsx
+ * const createMutation = useCreateCustomer();
+ *
+ * createMutation.mutate(formData, {
+ *   onSuccess: (data) => router.push(`/office/kunden/${data.id}`),
+ *   onError: (error) => toast.error(error.message),
+ * });
+ * ```
+ */
+export function useCreateCustomer() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: CustomerFormData) => {
+      const result = await createCustomerAction(data);
+      if (!result.success || !result.data) {
+        throw new Error(result.error || 'Fehler beim Erstellen des Kunden');
+      }
+      return result.data;
+    },
+    onSuccess: () => {
+      // Invalidate customers list to trigger refetch
+      void queryClient.invalidateQueries({ queryKey: queryKeys.customers.lists() });
+    },
+  });
+}
+
+/**
+ * Mutation hook for updating a customer.
+ * Invalidates cache on success.
+ *
+ * @returns Mutation object with mutate function
+ *
+ * @example
+ * ```tsx
+ * const updateMutation = useUpdateCustomer();
+ *
+ * updateMutation.mutate({ id: customerId, ...formData }, {
+ *   onSuccess: () => router.push(`/office/kunden/${customerId}`),
+ *   onError: (error) => toast.error(error.message),
+ * });
+ * ```
+ */
+export function useUpdateCustomer() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: CustomerFormData & { id: string }) => {
+      const result = await updateCustomerAction(data);
+      if (!result.success) {
+        throw new Error(result.error || 'Fehler beim Aktualisieren des Kunden');
+      }
+      return result.data;
+    },
+    onSuccess: (_data, variables) => {
+      // Invalidate both list and detail queries
+      void queryClient.invalidateQueries({ queryKey: queryKeys.customers.lists() });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.customers.detail(variables.id) });
     },
   });
 }

--- a/src/hooks/use-customers.ts
+++ b/src/hooks/use-customers.ts
@@ -5,10 +5,11 @@
  * Includes customer list and detail views with audit logs.
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getCustomersListAction,
   getCustomerDetailAction,
+  deleteCustomerAction,
 } from '@/app/actions/customer.actions';
 import { queryKeys } from '@/lib/query-keys';
 
@@ -60,6 +61,40 @@ export function useCustomerDetail(id: string) {
         throw new Error(result.error || 'Failed to fetch customer detail');
       }
       return result.data;
+    },
+  });
+}
+
+/**
+ * Mutation hook for deleting a customer.
+ * Invalidates cache on success.
+ *
+ * @returns Mutation object with mutate function
+ *
+ * @example
+ * ```tsx
+ * const deleteMutation = useDeleteCustomer();
+ *
+ * deleteMutation.mutate(customerId, {
+ *   onSuccess: () => router.push('/office/kunden'),
+ *   onError: (error) => toast.error(error.message),
+ * });
+ * ```
+ */
+export function useDeleteCustomer() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const result = await deleteCustomerAction({ id });
+      if (!result.success) {
+        throw new Error(result.error || 'Fehler beim Löschen des Kunden');
+      }
+      return result;
+    },
+    onSuccess: () => {
+      // Invalidate customers list to trigger refetch
+      void queryClient.invalidateQueries({ queryKey: queryKeys.customers.lists() });
     },
   });
 }


### PR DESCRIPTION
## Summary
- Add delete button to customer detail page (`/office/kunden/{id}`)
- Confirmation dialog asks user to confirm before deletion
- Toast notification on success/error
- Automatic redirect to customer list after deletion

## Additional Fixes
- **Fixed React Query cache invalidation**: Added `useCreateCustomer` and `useUpdateCustomer` mutation hooks so the customer list refreshes after create/edit operations
- **Fixed toast library**: Changed from react-toastify to sonner (the shadcn/ui standard already used in the codebase)
- **Added ToastProvider**: Properly set up sonner's Toaster component in RootProviders

## Changes
- `src/hooks/use-customers.ts` - Added mutation hooks for create, update, delete
- `src/components/customers/customer-form.tsx` - Use mutation hooks instead of direct action calls
- `src/app/office/kunden/[id]/page.tsx` - Added delete button with AlertDialog
- `src/components/ui/alert-dialog.tsx` - New AlertDialog component
- `src/components/providers/toast-provider.tsx` - Sonner Toaster setup
- `src/components/providers/root-providers.tsx` - Include ToastProvider
- `src/app/layout.tsx` - Removed react-toastify CSS import

## Test plan
- [ ] Navigate to any customer detail page
- [ ] Click the red "Löschen" button
- [ ] Verify confirmation dialog appears
- [ ] Click "Abbrechen" to cancel (dialog closes)
- [ ] Click "Ja, löschen" to confirm
- [ ] Verify toast message and redirect to customer list
- [ ] Create a new customer and verify it appears in the list immediately
- [ ] Edit a customer and verify changes appear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)